### PR TITLE
Changing initial repo to our artifactory proxy repo

### DIFF
--- a/upside-core.gradle
+++ b/upside-core.gradle
@@ -26,14 +26,7 @@ allprojects {
                 username = maven_user
                 password = maven_user_api_key
             }
-            url 'https://upside.artifactoryonline.com/upside/libs-snapshot/'
-        }
-        maven {
-            credentials {
-                username = maven_user
-                password = maven_user_api_key
-            }
-            url 'https://upside.artifactoryonline.com/upside/libs-release/'
+            url 'https://upside.artifactoryonline.com/upside/repo/'
         }
         mavenLocal()
     }


### PR DESCRIPTION
The "publishing" section should still stay the same, but I think if we
change where our primary repo points to so that we're using the
uber/proxy repo in artifactory, then some of the client problems we're
having (e.g. can't download sources) should go away