### PR TITLE
Update dependency management to latest AWS SDK

### DIFF
--- a/upside-dependency-management.gradle
+++ b/upside-dependency-management.gradle
@@ -74,7 +74,7 @@ allprojects {
             dependency 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.5'
             dependency 'com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.8.5'
 
-            dependencySet(group:'com.amazonaws', version: '1.10.48') {
+            dependencySet(group:'com.amazonaws', version: '1.11.84') {
                 entry('aws-java-sdk-core')
                 entry('aws-java-sdk-cognitoidentity')
                 entry('aws-java-sdk-ses')


### PR DESCRIPTION
Our version is pretty old; shall we update and see what happens? https://aws.amazon.com/releasenotes/Java?browse=1