### PR TITLE
UP-1479 Adding whitesource configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .gradle
 build/
+.idea/
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/upside-core.gradle
+++ b/upside-core.gradle
@@ -1,8 +1,8 @@
 buildscript {
     repositories { jcenter() }
     dependencies {
-        classpath 'com.netflix.nebula:nebula-publishing-plugin:4.9.1'
-        classpath 'com.netflix.nebula:nebula-release-plugin:4.1.0'
+        classpath 'com.netflix.nebula:nebula-publishing-plugin:5.1.1'
+        classpath 'com.netflix.nebula:nebula-release-plugin:6.0.0'
     }
 }
 

--- a/upside-dependency-management.gradle
+++ b/upside-dependency-management.gradle
@@ -81,11 +81,17 @@ allprojects {
                 entry('aws-java-sdk-dynamodb')
             }
 
+            /* Manually set 2017/08/02 because of a Whitesource warning about our 'natural' transitive dependency */
+            dependency 'ch.qos.logback:logback-classic:1.2.3'
+
             dependencySet(group:'ch.qos.logback.contrib', version: '0.1.2') {
                 entry('logback-json-classic')
                 entry('logback-json-core')
                 entry('logback-jackson')
             }
+
+            /* Manually set 2017/08/02 because of a Whitesource warning about our 'natural' v3.4 transitive dependency */
+            dependency 'org.apache.commons:commons-lang3:3.6'
 
             /*Redis*/
             dependency 'com.github.spullara.mustache.java:compiler:0.9.1'
@@ -110,7 +116,7 @@ allprojects {
             dependency 'org.zalando:jackson-datatype-money:0.6.0'
 
             /*MySQL*/
-            dependency 'mysql:mysql-connector-java:5.1.38'
+            dependency 'mysql:mysql-connector-java:5.1.43'
             dependency 'org.flywaydb:flyway-core:3.2.1'
             dependency 'org.jdbi:jdbi:2.73'
             dependency 'org.antlr:stringtemplate:3.2.1'

--- a/upside-whitesource.gradle
+++ b/upside-whitesource.gradle
@@ -1,0 +1,16 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath group: 'org.whitesource', name: 'whitesource-gradle-plugin', version: '0.8'
+    }
+}
+
+apply plugin: org.whitesource.gradle.WhitesourcePlugin
+
+allprojects {
+    whitesource {
+       orgToken '95f598fa-2a79-425a-b679-63008f05847d'
+    }
+}


### PR DESCRIPTION
During testing, I also noticed a couple of 'severe' or 'critical'
library upgrades that whitesource recommended in the attribute-service,
so this also:

* upgrades logback
* upgrades commons-lang3 from v3.4 to 3.6
* upgrades the mysql-connector-j from 5.1.38 to 5.1.43