### PR TITLE
Removing this lame library support module now that all libraries are mvn

### DIFF
--- a/upside-library.gradle
+++ b/upside-library.gradle
@@ -1,3 +1,0 @@
-apply from: 'https://raw.githubusercontent.com/upside-services/upside-gradle/master/upside-core.gradle'
-apply plugin: 'java'
-


### PR DESCRIPTION
We want to move from gradle -> mvn and the easiest first step is standardizing all our non-services on maven.  That was completed in the last 24 hours with the conversion of lib-rest and the gasbuddy-integration (java client), so this file is no longer used