### PR TITLE
[donotmerge] noissue: update nebula to 6.0.0 for gradle 5+ support

### DIFF
--- a/upside-autovalue.gradle
+++ b/upside-autovalue.gradle
@@ -13,10 +13,8 @@ buildscript {
 allprojects {
     apply plugin: net.ltgt.gradle.apt.AptPlugin
     dependencies {
-        compileOnly "com.google.auto.value:auto-value:1.6.2"
-        compileOnly "com.google.auto.value:auto-value-annotations:1.6.2"
-        apt         "com.google.auto.value:auto-value:1.6.2" 
-        apt         "com.google.auto.value:auto-value-annotations:1.6.2"         
+        compile             "com.google.auto.value:auto-value-annotations:1.6.2"
+        annotationProcessor "com.google.auto.value:auto-value:1.6.2"      
     }
 }
 

--- a/upside-service.gradle
+++ b/upside-service.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.netflix.nebula:gradle-ospackage-plugin:4.0.0'
+        classpath 'com.netflix.nebula:gradle-ospackage-plugin:6.0.0'
     }
 }
 


### PR DESCRIPTION
- also updates autovalue to fix how annotationpreprocessors are spec'ed